### PR TITLE
Require port for all methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,61 @@
+# Conex
+
+A CLI tool to connect to network devices with automatic fallback across SSH, Telnet, and console methods.
+
+## Installation
+
+```bash
+pip install .
+```
+
+The command `conex` will be available on your `PATH`.
+
+## Usage
+
+```bash
+conex <hostname> [--config path/to/hosts.yaml]
+```
+
+By default the configuration is loaded from `~/.conex/hosts.yaml` or from the
+path specified in the `CONEX_HOSTS_FILE` environment variable.
+
+### Configuration file format
+
+The host configuration can be written either using legacy keys or a more flexible
+list of connection entries. The simplest approach is to provide a list directly
+under each hostname. Each item declares the connection `type` and credentials:
+
+```yaml
+hostname1:
+  - type: ssh
+    ip: 192.168.1.10
+    port: 22
+    username: admin
+    password: cisco123
+  - type: telnet
+    ip: 192.168.1.10
+    port: 23
+    username: admin
+    password: cisco123
+  - type: console_ssh
+    ip: 192.168.1.20
+    port: 2222
+    username: console
+    password: c0ns0le
+  - type: console_telnet
+    ip: 192.168.1.20
+    port: 2323
+    username: console
+    password: c0ns0le
+```
+
+You may also nest the list under a `connections:` key if you prefer to keep
+additional settings alongside the host entry.
+
+The legacy dictionary style with `ssh`, `telnet`, and `console` keys is still
+accepted for backward compatibility. Connection attempts always occur in the
+following order when present: `ssh`, `telnet`, `console_ssh`, then
+`console_telnet`.
+
+Every entry must include a `port` field. This keeps the format consistent and
+avoids relying on implicit defaults.

--- a/conex/__init__.py
+++ b/conex/__init__.py
@@ -1,0 +1,2 @@
+"""Conex package."""
+__all__ = ["cli", "connection_manager", "logger"]

--- a/conex/cli.py
+++ b/conex/cli.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import argparse
+import sys
+
+from .connection_manager import ConnectionManager, load_config
+from .logger import logger
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Connect to host")
+    parser.add_argument("hostname", help="Hostname to connect to")
+    parser.add_argument(
+        "--config",
+        help="Path to hosts YAML file (default: ~/.conex/hosts.yaml or CONEX_HOSTS_FILE)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        config = load_config(args.config)
+    except FileNotFoundError:
+        logger.error("Configuration file not found")
+        return 1
+
+    manager = ConnectionManager(config)
+    try:
+        method = manager.connect(args.hostname)
+        logger.info(f"Successfully connected using {method}")
+        return 0
+    except Exception as exc:  # catch all connection errors
+        logger.error(str(exc))
+        return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/conex/connection_manager.py
+++ b/conex/connection_manager.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import os
+import yaml
+from typing import Dict, Any, Optional, Iterable, Tuple
+
+from .logger import logger
+
+try:
+    import paramiko
+except ImportError:  # pragma: no cover - paramiko missing during tests
+    paramiko = None
+
+import telnetlib
+
+DEFAULT_CONFIG_PATH = os.path.expanduser("~/.conex/hosts.yaml")
+ENV_CONFIG = "CONEX_HOSTS_FILE"
+
+
+def load_config(path: Optional[str] = None) -> Dict[str, Any]:
+    path = path or os.getenv(ENV_CONFIG, DEFAULT_CONFIG_PATH)
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+class ConnectionManager:
+    def __init__(self, config: Dict[str, Any]):
+        self.config = config
+
+    def connect(self, hostname: str) -> str:
+        host_cfg = self.config.get(hostname)
+        if not host_cfg:
+            raise ValueError(f"Host '{hostname}' not found in configuration")
+        for name, method, info in self._iter_methods(host_cfg):
+            ip = info["ip"]
+            port = info["port"]
+            logger.info(f"Trying {name}:{port} on {ip}")
+            try:
+                method(info)
+                logger.info(f"Connected via {name}")
+                return name
+            except Exception as exc:
+                logger.error(f"{name} failed: {exc}")
+
+        raise RuntimeError("All connection methods failed")
+
+    def _iter_methods(self, host_cfg: Any) -> Iterable[Tuple[str, callable, Dict[str, Any]]]:
+        """Yield connection methods for a host in priority order.
+
+        `host_cfg` may be a list directly under the hostname or a dictionary
+        containing a `connections` list. Legacy keys like `ssh` and `telnet`
+        are also accepted for backward compatibility. Each entry must include a
+        `port` so all connection types share the same schema.
+        """
+        methods = []
+        if isinstance(host_cfg, list):
+            methods = host_cfg
+        elif isinstance(host_cfg, dict):
+            if isinstance(host_cfg.get("connections"), list):
+                methods = host_cfg["connections"]
+            else:
+                def add(key, entry, conv=None):
+                    if entry is None or str(entry).lower() == "none":
+                        return
+                    item = dict(entry)
+                    if conv:
+                        conv(item)
+                    else:
+                        item.setdefault("type", key)
+                    methods.append(item)
+
+                add("ssh", host_cfg.get("ssh"))
+                add("telnet", host_cfg.get("telnet"))
+                add("console_ssh", host_cfg.get("console_ssh"))
+                add("console_telnet", host_cfg.get("console_telnet"))
+
+                def conv_console(d):
+                    typ = (d.get("type") or "ssh").lower()
+                    d["type"] = f"console_{typ}"
+
+                add("console", host_cfg.get("console"), conv_console)
+        else:
+            raise ValueError("Invalid host configuration format")
+
+        priority = {
+            "ssh": 0,
+            "telnet": 1,
+            "console_ssh": 2,
+            "console_telnet": 3,
+        }
+
+        def sort_key(item):
+            t = str(item.get("type", "")).lower().replace("-", "_")
+            return priority.get(t, 99)
+
+        for item in sorted(methods, key=sort_key):
+            t = str(item.get("type", "")).lower().replace("-", "_")
+            if "port" not in item:
+                raise ValueError(f"{t} requires a port")
+            if t == "telnet":
+                yield "Telnet", self._connect_telnet, item
+            elif t == "console_telnet":
+                yield "Console Telnet", self._connect_telnet, item
+            elif t == "console_ssh":
+                yield "Console SSH", self._connect_ssh, item
+            else:
+                yield "SSH", self._connect_ssh, item
+
+    def _connect_ssh(self, info: Dict[str, Any]):
+        if paramiko is None:
+            raise RuntimeError("paramiko not installed")
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        try:
+            client.connect(
+                hostname=info["ip"],
+                port=info["port"],
+                username=info.get("username"),
+                password=info.get("password"),
+                look_for_keys=False,
+                allow_agent=False,
+                timeout=5,
+                banner_timeout=5,
+                auth_timeout=5,
+            )
+        finally:
+            client.close()
+
+    def _connect_telnet(self, info: Dict[str, Any]):
+        host = info["ip"]
+        port = info["port"]
+        tn = telnetlib.Telnet(host, port, timeout=5)
+        username = info.get("username")
+        password = info.get("password")
+        if username:
+            tn.read_until(b"login:")
+            tn.write(username.encode("ascii") + b"\n")
+        if password:
+            tn.read_until(b"Password:")
+            tn.write(password.encode("ascii") + b"\n")
+        tn.close()
+

--- a/conex/logger.py
+++ b/conex/logger.py
@@ -1,0 +1,12 @@
+from loguru import logger
+from rich.console import Console
+
+console = Console()
+
+# Configure loguru to use rich for formatting
+logger.remove()
+
+LOG_FORMAT = "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level}</level> | <level>{message}</level>"
+logger.add(lambda msg: console.print(msg, end=""), colorize=True, format=LOG_FORMAT)
+
+__all__ = ["logger", "console"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "conex"
+version = "0.1.0"
+description = "CLI tool to connect to devices using SSH/Telnet with fallback"
+authors = [{name="Auto Generated"}]
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "PyYAML",
+    "rich",
+    "loguru",
+    "paramiko"
+]
+
+[project.scripts]
+conex = "conex.cli:main"


### PR DESCRIPTION
## Summary
- require ports in all connection entries
- simplify output to show connection attempts without spinner

## Testing
- `python3 -m pip install -e .` *(fails: build dependencies could not be installed)*
- `python3 -m conex.cli --help` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_6855f6aad3f4832a8d8efd9fb635b038